### PR TITLE
VULN-6193 Bump org.testng

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
       <dependency>
         <groupId>org.testng</groupId>
         <artifactId>testng</artifactId>
-        <version>7.0.0</version>
+        <version>7.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.junit</groupId>


### PR DESCRIPTION
This commit updates org.testng to version 7.7.1 in order to solve a vulnerability described in https://github.com/advisories/GHSA-rc2q-x9mf-w3vf